### PR TITLE
Fix null error for any language not en-us or zh-cn

### DIFF
--- a/openweb.js
+++ b/openweb.js
@@ -24,7 +24,7 @@
   // detect Web Environment Integrity API
   if (navigator.getEnvironmentIntegrity !== undefined) {
     // fuck it
-    alert(translations[lang]['alert']);
+    alert((translations[lang]??translations['en-us'])['alert']);
     window.location.href = home_url;
   }
 })();


### PR DESCRIPTION
Fall back to the en-us wording for any language that doesn't match 'en-us' (eg 'en-au')