### PR TITLE
Change CDN for the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Fight For the Open Web
 
 ```javascript
-<script src="https://raw.githubusercontent.com/Young-Lord/fight-for-the-open-web/main/openweb.js" defer async></script>
+<script src="https://cdn.jsdelivr.net/gh/Young-Lord/fight-for-the-open-web@main/openweb.js" defer async></script>
 ```
 
 English | [简体中文](./README.zh-CN.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,7 +1,7 @@
 # Fight For the Open Web
 
 ```javascript
-<script src="https://raw.githubusercontent.com/Young-Lord/fight-for-the-open-web/main/openweb.js" defer async></script>
+<script src="https://cdn.jsdelivr.net/gh/Young-Lord/fight-for-the-open-web@main/openweb.js" defer async></script>
 ```
 
 [English](./README.md) | 简体中文


### PR DESCRIPTION
I've tried adding this script to locally-hosted website just to try it out and I got

> The resource from “https://raw.githubusercontent.com/Young-Lord/fight-for-the-open-web/main/openweb.js” was blocked due to MIME type (“text/plain”) mismatch (X-Content-Type-Options: nosniff).

The same issue with the real website hosted in the cloud. I've replaced `raw.githubusercontent.com` with `cdn.jsdelivr.net` and it seems to be working.